### PR TITLE
Fix unresolved dependency error

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,11 +111,11 @@ Add this to **top** level `build.gradle`:
 
 Add this under dependencies:
 
-    compile 'com.github.worker8:RadioGroupPlus:v1.0.1'
+    implementation 'com.github.worker8:radiogroupplus:v1.0.1'
 
 If you run into conflict, use this instead:
 
-    compile('com.github.worker8:RadioGroupPlus:v1.0.1') {
+    implementation('com.github.worker8:radiogroupplus:v1.0.1') {
         transitive = false;
     }
     


### PR DESCRIPTION
Capitalized dependency ('com.github.worker8:RadioGroupPlus:v1.0.1') resulted in error:

`Failed to resolve: RadioGroup Plus Affected Modules: <a href="openFile:C:/Users/{User}/{ProjectFolder}/{Project}/app/build.gradle">app</a>`

Error was resolved by changing to ('com.github.worker8:radiogroupplus:v1.0.1')